### PR TITLE
Cancel any animations when the user starts to interact with the scroll view

### DIFF
--- a/ScrollExample/Sources/SimpleScrollView.swift
+++ b/ScrollExample/Sources/SimpleScrollView.swift
@@ -89,6 +89,14 @@ class SimpleScrollView: UIView {
         }
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        
+        // Freeze the scroll view at its current position so that the user can
+        // interact with its content or scroll it.
+        stopOffsetAnimation()
+    }
+    
     private func stopOffsetAnimation() {
         contentOffsetAnimation?.invalidate()
         contentOffsetAnimation = nil


### PR DESCRIPTION
Previously, the view would keep scrolling even if the user touched-down, and
then if the user tried to scroll the view in a different direction, the animation
would fight them.